### PR TITLE
Update to 7.6.8

### DIFF
--- a/libgc.cygport
+++ b/libgc.cygport
@@ -1,5 +1,5 @@
 NAME="libgc"
-VERSION=7.6.4
+VERSION=7.6.8
 RELEASE=1
 CATEGORY="Libs"
 SUMMARY="Boehm-Demers-Weiser garbage collector library"
@@ -11,7 +11,6 @@ automatically recycles memory when it determines that it can no longer
 be otherwise accessed."
 HOMEPAGE="http://www.hboehm.info/gc"
 SRC_URI="https://github.com/ivmai/bdwgc/releases/download/v${VERSION}/gc-${VERSION}.tar.gz"
-SRC_DIR="gc-${VERSION}"
 
 DEPEND="pkgconfig(atomic_ops)"
 


### PR DESCRIPTION
* Add cpu, make_as_lib, nothreads options to NT_MAKEFILE
* Adjust formatting of configure help messages and config.h comments
* Avoid multiple 'getcontext failed' warnings if getcontext is broken
* Do not call GC_dirty_inner unless GC_incremental
* Do not use NULL in gc_inline.h
* Eliminate 'cast between incompatible function types' compiler warning
* Eliminate 'condition is always true' cppcheck warning in init_gcj_malloc
* Eliminate 'declaration of var hides global declaration' compiler warning
* Eliminate 'language extension used' Clang warning in gc.h
* Eliminate 'possibly incorrect assignment in CORD_vsprintf' compiler warning
* Eliminate 'ptr arithmetic with NULL' cppcheck warning in alloc_mark_stack
* Eliminate 'scope of var can be reduced' cppcheck warning in pthread_join
* Eliminate 'switch statement contains no case label' compiler warning
* Eliminate 'variable might be uninitialized' warning in win32_start_inner
* Eliminate duplicate clear_mark_bit call when removing disappearing link
* Fix 'collecting from unknown thread' abort in leak-finding mode
* Fix 'pointer arithmetic with NULL' code defect in print_callers
* Fix comment about inv_sz computation in setup_header
* Fix comments style in configure.ac and Makefile.am
* Fix cords for MANUAL_VDB
* Fix GC_is_valid_displacement and GC_is_visible for non-small objects
* Fix gctest in leak-finding mode
* Fix large object base computation in PUSH_CONTENTS() if MARK_BIT_PER_OBJ
* Fix mark stack overflow checking in push_selected
* Fix missing GC_dirty calls for GC-allocated objects used internally
* Fix missing GC_dirty invocation from debug_end_stubborn_change
* Fix multi-threaded gctest for the case of NTHREADS is set to zero
* Fix potential null dereference in GC_CONS
* Fix register_dynamic_libraries on Windows 10
* Fix result computation in n_set_marks
* Fix return type in GC_set_warn_proc API documentation
* Fix tests for GC compiled with MANUAL_VDB
* Fix typo in comment for CORD_ec_flush_buf prototype
* Fix typos in ChangeLog and generic_malloc
* Fix UNTESTED for multi-threaded API functions in gctest
* Fix VirtualQuery call in case of malloc failure (Win32)
* Install gc.3 man page instead of copying gc.man to doc folder (configure)
* Keep pointer to the start of previous entry in remove_specific_after_fork
* Move de_win compiled resource files to cord/tests
* Never return null by C++ GC allocators and gc_cpp operator new
* Remove code duplication in gcj_malloc and malloc_explicitly_typed
* Remove duplicate local variable in reclaim_block
* Remove information how to send bugs from README.cords file
* Remove unused USE_GENERIC macro definition and description
* Turn on incremental collection in gctest also if MANUAL_VDB
* Update copyright information in alloc.c, gc.c/h and the documentation
* Update EXTRA_DIST in Makefile, Win32/64 docs after NT_*_MAKEFILE removal
* Workaround 'class C does not have a copy constructor' cppcheck warning
* Workaround 'function nested_sp is never used' cppcheck style warning
* Workaround 'opposite expression on both sides of &' cppcheck style warning

* Eliminate 'boolean result used in bitwise operation' cppcheck warning
* Eliminate 'there is pointer arithmetic with NULL' cppcheck warning
* Explicitly unblock GC signals on GC initialization
* Fix 'scope of var can be reduced' cppcheck err in enqueue_all_finalizers
* Fix assertion violation in DllMain of win32_threads
* Fix comment for debug_generic_malloc_inner[_ignore_off_page]
* Fix data race during apply_to_each_object(reset_back_edge)
* Fix dbg_mlc.c/o file name in documentation
* Fix include gc_gcj.h in thread_local_alloc.c
* Fix man section number (3)
* Fix missing GC_generic_malloc_words_small implementation in new_gc_alloc.h
* Fix missing new-line in ABORT_ARG<n> definition
* Fix null dereference in print_callers on backtrace_symbols failure
* Fix the collector hang when it is configured with --enable-gc-debug
* Fix type of local variables receiving result of PHT_HASH
* Fix typo in AIX macro name
* Fix typo in comment in specific.h
* Fix unbounded heap growth in case of intensive disappearing links usage
* Workaround 'address of auto-variable returned' cppcheck error